### PR TITLE
Modify AvoidUsernameAndPassword and AvoidReservedParams

### DIFF
--- a/Rules/AvoidUserNameAndPasswordParams.cs
+++ b/Rules/AvoidUserNameAndPasswordParams.cs
@@ -34,8 +34,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
             IEnumerable<Ast> functionAsts = ast.FindAll(testAst => testAst is FunctionDefinitionAst, true);
 
             List<String> passwords = new List<String>() {"Password", "Passphrase"};
-            List<String> usernames = new List<String>() { "Username", "User", "ID", "APIKey", "Key",
-                                                        "Account", "Name" };
+            List<String> usernames = new List<String>() { "Username", "User"};
 
             foreach (FunctionDefinitionAst funcAst in functionAsts)
             {

--- a/Rules/ScriptAnalyzerBuiltinRules.csproj
+++ b/Rules/ScriptAnalyzerBuiltinRules.csproj
@@ -61,7 +61,7 @@
     <Compile Include="AvoidShouldContinueWithoutForce.cs" />
     <Compile Include="AvoidTrapStatement.cs" />
     <Compile Include="AvoidUnitializedVariable.cs" />
-    <Compile Include="AvoidUserNameAndPasswordParams.cs" />
+    <Compile Include="AvoidUsernameAndPasswordParams.cs" />
     <Compile Include="AvoidUsingClearHost.cs" />
     <Compile Include="AvoidUsingComputerNameHardcoded.cs" />
     <Compile Include="AvoidUsingConvertToSecureStringWithPlainText.cs" />


### PR DESCRIPTION
Raise error when [cmdletbinding()] is used in AvoidReservedParamsRule

Modify the list of strings to search in AvoidUsernameAndPassword. Also
change the name of the rule to CamelCase.